### PR TITLE
remove broken demos

### DIFF
--- a/templates/demos.html
+++ b/templates/demos.html
@@ -13,45 +13,33 @@
     </div>
    <div class="row">
     <div class="who__wrapper">
-      <div class="large-4 columns">
+      <div class="large-6 columns">
         <a href="http://openregister-food-ratings-demo.herokuapp.com/"><img src="/static/images/demo/food-premises-ratings.jpg"></a>
         <h3 class="heading-medium"><a href="http://openregister-food-ratings-demo.herokuapp.com/">Food premises ratings</a></h3>
          <p>An application showing food premises and their ratings.
           A small <a href="https://github.com/openregister/food-ratings-demo">python/flask application</a>.</p>
       </div>
-      <div class="large-4 columns end">
+      <div class="large-6 columns end">
         <a href="http://openregister-food-registration.herokuapp.com/"><img src="/static/images/demo/food-premises-registration.jpg"></a>
         <h3 class="heading-medium"><a href="http://openregister-food-registration.herokuapp.com/">Food premises registration</a></h3>
          <p>A form driven by company, food premises and other registers.
         A small <a href="https://github.com/openregister/food-premises-registration">python/flask application</a>.</p>
       </div>
-      <div class="large-4 columns end">
-        <a href="http://openregister-fsa-demo.herokuapp.com/"><img src="/static/images/demo/fsa-demo.jpg"></a>
-        <h3 class="heading-medium"><a href="http://openregister-fsa-demo.herokuapp.com/">Approved food premises</a></h3>
-         <p>An application showing premises approved for the handling or processing of products of animal origin.
-        A small <a href="https://github.com/openregister/food-premises-demo">python/flask application</a>.</p>
-      </div>
     </div>
   </div>
   <div class="row">
     <div class="who__wrapper">
-      <div class="large-4 columns">
+      <div class="large-6 columns">
         <a href="http://openregister-school-demo.herokuapp.com/"><img src="/static/images/demo/school-finder.jpg"></a>
         <h3 class="heading-medium"><a href="http://openregister-school-demo.herokuapp.com/">School finder</a></h3>
          <p>A page for every <a href="http://school.openregister.org">school</a> showing related information from other registers.
         A small <a href="https://github.com/openregister/school-demo">python/flask application</a>.</p>
       </div>
-      <div class="large-4 columns">
+      <div class="large-6 columns">
         <a href="http://openregister-widgets.herokuapp.com/"><img src="/static/images/demo/widgets.jpg"></a>
         <h3 class="heading-medium"><a href="http://openregister-widgets.herokuapp.com/">Widgets</a></h3>
         <p>A page of widget built using registers.
         <a href="https://github.com/openregister/openregister-widgets">Javascript widgets served by a python/flask application</a>.</p>
-      </div>
-      <div class="large-4 columns">
-        <a href="http://openregister-check-demo.herokuapp.com/"><img src="/static/images/demo/check.jpg"></a>
-        <h3 class="heading-medium"><a href="http://openregister-check-demo.herokuapp.com/">Check a licence or certificate</a></h3>
-        <p>A prototype application demonstrating digital proofs.
-        A small <a href="https://github.com/openregister/check-demo">python/flask application</a>.</p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Remove the openregister-fsa-demo and openregister-check-demo.  Both were
broken and not used.

To fill the page, I've expanded the remaining demos to be
half-page-width rather than one-third-page-width.

Screenshot of new view:

<img width="1412" alt="screen shot 2016-03-07 at 15 01 16" src="https://cloud.githubusercontent.com/assets/581269/13573048/884de0bc-e475-11e5-85dc-d56d630bf3ea.png">

ping @stephenjoe1 
